### PR TITLE
fix: add workflow params for tag-only release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,4 +72,8 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         root_options: "-vv"
+        commit: "false"
+        push: "false"
+        tag: "true"
+        vcs_release: "true"
 


### PR DESCRIPTION
## Summary

Adds workflow-level parameters to override semantic-release configuration and ensure tag-only behavior.

## Problem

Despite setting `commit = false` and `push = false` in `pyproject.toml`, semantic-release continues attempting to push to the protected main branch, causing workflow failures.

## Solution

Add explicit parameters to the GitHub Action to override configuration:

```yaml
- name: Python Semantic Release
  uses: python-semantic-release/python-semantic-release@v9.15.0
  with:
    commit: "false"
    push: "false" 
    tag: "true"
    vcs_release: "true"
```

## Expected Behavior

- ✅ **No commits created** - respects protected branch rules
- ✅ **No pushes attempted** - eliminates branch protection conflicts  
- ✅ **Tags created** - enables semantic versioning
- ✅ **GitHub releases generated** - provides release automation

## Testing

This should resolve the `Failed to push branch (main) to remote` error by ensuring semantic-release operates in tag-only mode.

## Related

- Continues work from PR #24 (tag-based release workflow)
- Addresses persistent push failures in issue #23

🤖 Generated with [Claude Code](https://claude.ai/code)