### PR TITLE
fix: remove push=false blocking VCS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,6 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         root_options: "-vv"
         commit: "false"
-        push: "false"
         tag: "true"
         vcs_release: "true"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ remove_dist = false
 major_on_zero = false
 tag_format = "v{version}"
 commit = false
-push = false
 tag = true
 vcs_release = true
 


### PR DESCRIPTION
## Summary

Fixes semantic-release not creating tags/releases by removing the `push = false` configuration that was blocking VCS operations.

## Problem

Workflow logs showed:
```
INFO [version.version] No vcs release will be created because pushing changes is disabled
```

The `push = false` setting was preventing **all** VCS operations, including tag and release creation, not just commit pushes.

## Solution

**Configuration changes:**

1. **Remove `push = false`** from `pyproject.toml` 
2. **Remove `push: "false"`** from workflow parameters
3. **Keep `commit = false`** to prevent version bump commits

**Expected behavior:**
- ✅ **Tags created** - Semantic version tags will be pushed to GitHub
- ✅ **Releases created** - GitHub releases with auto-generated notes  
- ❌ **No commits** - `commit = false` prevents version bump commits to main
- ❌ **No branch pushes** - Protected branch rules still enforced

## Key Insight

Semantic-release interprets `push = false` as "disable all remote operations" rather than "don't push commits". Since we have `commit = false`, there are no commits to push anyway - removing `push = false` only enables tag/release creation.

## Testing Plan

- [ ] Merge PR to main
- [ ] Verify workflow creates actual tags: `git tag --list` 
- [ ] Verify GitHub releases created: `gh release list`
- [ ] Confirm no commits pushed to main branch
- [ ] Validate release contains distribution artifacts

## Resolves

- Fixes #26 (semantic-release not creating tags/releases)
- Completes tag-based release workflow implementation

🤖 Generated with [Claude Code](https://claude.ai/code)